### PR TITLE
[AT-969] Update aerospike client to 4.0.8; Support Query API

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Scaerospike extends Build {
       	organization := "com.tapad.scaerospike"
       ) ++ Seq(libraryDependencies ++=
         Seq(
-          "com.aerospike" % "aerospike-client" % "3.0.30",
+          "com.aerospike" % "aerospike-client" % "4.0.8",
           "io.netty" % "netty-buffer" % "4.0.23.Final",
           "org.scalatest" %% "scalatest" % "2.2.6"  % "test"
         )

--- a/src/main/scala/com/tapad/aerospike/ClientSettings.scala
+++ b/src/main/scala/com/tapad/aerospike/ClientSettings.scala
@@ -1,7 +1,7 @@
 package com.tapad.aerospike
 
 import com.aerospike.client.async.{MaxCommandAction, AsyncClientPolicy}
-import com.aerospike.client.policy.{WritePolicy, QueryPolicy}
+import com.aerospike.client.policy.{BatchPolicy, Policy, WritePolicy, QueryPolicy}
 import java.util.concurrent.ExecutorService
 
 /**
@@ -31,9 +31,25 @@ object ClientSettings {
 
 
 case class ReadSettings(timeout: Int = 0, maxRetries: Int = 2, sleepBetweenRetries: Int = 500, maxConcurrentNodes: Int = 0) {
+  private[aerospike] def buildReadPolicy() = {
+    val p = new Policy()
+    p.setTimeout(timeout)
+    p.maxRetries          = maxRetries
+    p.sleepBetweenRetries = sleepBetweenRetries
+    p
+  }
+
+  private[aerospike] def buildBatchPolicy() = {
+    val p = new BatchPolicy()
+    p.setTimeout(timeout)
+    p.maxRetries          = maxRetries
+    p.sleepBetweenRetries = sleepBetweenRetries
+    p
+  }
+
   private[aerospike] def buildQueryPolicy() = {
     val p = new QueryPolicy()
-    p.timeout             = timeout
+    p.setTimeout(timeout)
     p.maxRetries          = maxRetries
     p.sleepBetweenRetries = sleepBetweenRetries
     p.maxConcurrentNodes  = maxConcurrentNodes
@@ -45,14 +61,16 @@ object ReadSettings {
   val Default = ReadSettings()
 }
 
-case class WriteSettings(expiration: Int = 0, timeout: Int = 0, maxRetries: Int = 2, sleepBetweenRetries: Int = 500) {
+case class WriteSettings(expiration: Int = 0, timeout: Int = 0, maxRetries: Int = 2, sleepBetweenRetries: Int = 500, sendKey: Boolean = false) {
   private[aerospike] def buildWritePolicy() = {
-    val p = new WritePolicy()
-    p.expiration = expiration
-    p.timeout = timeout
-    p.maxRetries = maxRetries
-    p.sleepBetweenRetries = sleepBetweenRetries
-    p
+    val p = new Policy()
+    p.sendKey = sendKey
+    val wp = new WritePolicy(p)
+    wp.expiration = expiration
+    wp.setTimeout(timeout)
+    wp.maxRetries = maxRetries
+    wp.sleepBetweenRetries = sleepBetweenRetries
+    wp
   }
 }
 


### PR DESCRIPTION
# Testing

1. Tested query API for the cpu_utilization set:
aql> select * from test.cpu_utilization
+---------------------------------------------+-------------------+---------------+-------------+
| PK                                          | avgCpu            | timeStamp     | trafficType |
+---------------------------------------------+-------------------+---------------+-------------+
| "ec2-54-159-69-124.compute-1.amazonaws.com" | 79.42760969673394 | 1510175324188 | "exchange"  |
| "ec2-54-84-112-189.compute-1.amazonaws.com" | 73.41829342827779 | 1510175335763 | "exchange"  |
+---------------------------------------------+-------------------+---------------+-------------+
2 rows in set (0.028 secs)

Test code:
    val stmt = new Statement()
    stmt.setNamespace("test")
    stmt.setSetName("cpu_utilization")
    stmt.setFilter(Filter.equal("trafficType", "exchange"))
    UserstoreAerospikeClient.UserProfileSetOps.query(stmt) foreach { m =>
      logger.info("PHUTEST map = " + m)
    }

Output:
Map(ec2-54-159-69-124.compute-1.amazonaws.com -> (gen:16),(exp:250464224),(bins:(timeStamp:1510176224164),(avgCpu:78.23558607858752),(trafficType:exchange)), ec2-54-84-112-189.compute-1.amazonaws.com -> (gen:16),(exp:250464235),(bins:(timeStamp:1510176235721),(avgCpu:73.03427051274991),(trafficType:exchange)))
